### PR TITLE
Add coordinator-guided engine loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,53 @@
+# Multi-Role Cognitive Engine (MRCE)
+
+MRCE is a small experimental framework exploring multi-agent interaction with a local LLM. Each agent keeps its own memory and the system coordinates them via a simple finite state machine. A "Phase‑Crystal" memory stores modulated embeddings and a FECR vector evolves from the stored crystals.
+
+## Repository layout
+
+```
+configs/          # YAML persona definitions
+logs/             # CSV conversation logs
+mrce/             # Core package (agents, memory, FECR utilities)
+scripts/          # Demo entrypoints
+tests/            # Pytest suite
+```
+
+Key modules:
+
+- **`mrce/phasecrystal/memory.py`** – sliding window memory that scores resonance and promotes stable "crystals".
+- **`mrce/fecr/`** – helpers for computing the FECR vector and modulating embeddings.
+- **`mrce/llm/ollama_client.py`** – minimal wrapper for a local Ollama server providing chat completions and embeddings.
+- **`mrce/mrcore/`** – agents, coordinator FSM and the `MRCEngine` that ties everything together.
+- **`scripts/smoke_engine.py`** – interactive demo using `MRCEngine`.
+
+Persona configurations live under `configs/personae/` and define system prompts for each expert agent.
+
+## Quick start
+
+1. **Install dependencies** (Python 3.11):
+   ```bash
+   pip install -r requirements.txt
+   ```
+   Using the provided virtual environment (`venv/` or `.venv/`) is also possible.
+2. **Run the engine demo**:
+   ```bash
+   python scripts/smoke_engine.py [--debug]
+   ```
+   Use `--debug` to print FECR and resonance metrics each turn.
+   The loop calls the coordinator at the start and end of each round. Enter text
+   to prime the first turn, then press Enter to continue through subsequent rounds
+   or type `quit` to exit.
+
+Logs are written to `logs/MRCE_chat_<n>.csv` when `mrce/utils/logger.py` has `CSV_LOGGING = True`.
+
+## Running tests
+
+The project has a small pytest suite checking the Phase‑Crystal memory:
+
+```bash
+pytest
+```
+
+## License
+
+This project is licensed under the MIT License. See `pyproject.toml` for details.

--- a/mrce/fecr/modulator.py
+++ b/mrce/fecr/modulator.py
@@ -11,14 +11,15 @@ import numpy as np
 from typing import List
 
 def _make_matrix(phi: List[float], d: int) -> np.ndarray:
-    blocks = len(phi)
-    base   = d // blocks
-    gains  = np.repeat(phi, base).astype("float32")
-    if gains.size < d:                       # pad tail if d % 13 != 0
-        gains = np.concatenate([gains, np.repeat(phi[-1], d - gains.size)])
-    return np.diag(gains)
+    gain = 1.0 + np.array(phi, dtype="float32")
+    base = d // len(phi)
+    g = np.repeat(gain, base)
+    if g.size < d:
+        g = np.concatenate([g, np.repeat(gain[-1], d - g.size)])
+    g /= np.linalg.norm(g) / np.sqrt(d)
+    return np.diag(g)
 
-def modulate(emb: np.ndarray, phi: List[float]) -> np.ndarray:
+def modulate(emb: np.ndarray, phi: list[float]) -> np.ndarray:
     """Return W(φ)·e  (same shape as emb)."""
     if not phi:                              # safety fallback
         return emb

--- a/mrce/llm/ollama_client.py
+++ b/mrce/llm/ollama_client.py
@@ -62,7 +62,7 @@ async def chat(
 
 
 # ---------------------------------------------------------------- embed ---
-async def embed(text: str, model: str = "llama3:8b") -> List[float]:
+async def embed(text: str, model: str = "llama3:8b") -> list[float]:
     """
     Get an embedding vector. 120‑second timeout; on timeout returns [] so
     Phase‑Crystal logic can skip that turn instead of crashing.
@@ -74,7 +74,10 @@ async def embed(text: str, model: str = "llama3:8b") -> List[float]:
             r = await client.post(f"{OLLAMA_HOST}/api/embeddings", json=payload)
             r.raise_for_status()
             return r.json()["embedding"]
-        except (httpx.ReadTimeout, httpx.ConnectTimeout):
-            # log + return empty vector
+        except httpx.TimeoutException:
             print("[embed] timeout — skipping embedding for this turn")
             return []
+        except httpx.HTTPError as e:
+            print(f"[embed] http error: {e}")
+            return []
+

--- a/mrce/mrcore/coordinator.py
+++ b/mrce/mrcore/coordinator.py
@@ -19,10 +19,28 @@ from __future__ import annotations
 import re
 from enum import Enum, auto
 from typing import Dict, List, Tuple
+import numpy as np
 
 from mrce.llm import ollama_client
 from mrce.phasecrystal.memory import PhaseCrystalMemory
 from mrce.utils.logger import log_turn
+from mrce.settings import (
+    RESONANCE_WEIGHT,
+    CRITIC_WEIGHT,
+    INDIVIDUAL_WEIGHT,
+    PAIRWISE_WEIGHT,
+    TRUTH_Z,
+    FLOOR_TH,
+MAX_DIAL,
+)
+
+
+def contradict(a: str, b: str) -> bool:
+    antonyms = {"cannot": "can", "never": "always", "higher": "lower"}
+    for neg, pos in antonyms.items():
+        if (neg in a and pos in b) or (pos in a and neg in b):
+            return True
+    return False
 
 
 class State(Enum):
@@ -36,9 +54,6 @@ class State(Enum):
 
 # ---------------------------------------------------------------------------
 class CoordinatorFSM:
-    TRUTH_TH = 0.75        # score ≥ TRUTH_TH → CONVERGE
-    FLOOR_TH = 0.45        # score < FLOOR_TH → DIVERGE
-    MAX_DIAL = 3           # dialectic rounds
 
     def __init__(self, global_mem: PhaseCrystalMemory):
         self.state: State = State.OPEN
@@ -46,9 +61,14 @@ class CoordinatorFSM:
         self.global_mem  = global_mem
 
     # ....................................................
-    def guide(self, fecr_vec) -> str:
-        return ("Coordinator guidance: respond clearly; "
-                f"FECR first four = {[round(w,2) for w in fecr_vec[:4]]}")
+    def guide(self, prev: str | None, user_msg: str, fecr_vec) -> str:
+        parts = []
+        if prev:
+            parts.append(f"Prev ⇒ {prev}")
+        if user_msg:
+            parts.append(f"User ⇒ {user_msg}")
+        parts.append(f"φ₀₋₃={[round(w,2) for w in fecr_vec[:4]]}")
+        return " | ".join(parts)
 
     # ....................................................
     async def score_reply(self, persona: str, reply: str) -> Tuple[float, float]:
@@ -59,7 +79,7 @@ class CoordinatorFSM:
         # critic lines like "Logical rigor: 8/10"
         critic_match = re.search(r"(\d+(?:\.\d+)?)/10", reply)
         grade = float(critic_match.group(1)) / 10 if critic_match else 0.5
-        score = 0.6 * resonance + 0.4 * grade
+        score = RESONANCE_WEIGHT * resonance + CRITIC_WEIGHT * grade
         return score, resonance
 
     # ....................................................
@@ -69,19 +89,43 @@ class CoordinatorFSM:
         Decide next state, return (chosen_persona, text)
         """
         scored = {}
+        reson = {}
         for name, text in replies.items():
-            s, _ = await self.score_reply(name, text)
+            s, r = await self.score_reply(name, text)
             scored[name] = s
+            reson[name] = r
 
-        best_name = max(scored, key=scored.get)
-        best_score = scored[best_name]
+        embs = []
+        for text in replies.values():
+            emb = await ollama_client.embed(text)
+            if emb:
+                embs.append(np.asarray(emb, dtype="float32"))
+        pairwise = 0.0
+        if len(embs) >= 2:
+            M = np.stack(embs)
+            norm = np.linalg.norm(M, axis=1)
+            sims = (M @ M.T) / (norm[:, None] * norm[None, :] + 1e-9)
+            pairwise = float(sims[np.triu_indices(len(embs), 1)].mean())
 
-        if best_score >= self.TRUTH_TH:
+        final_scores = {
+            name: INDIVIDUAL_WEIGHT * scored[name] + PAIRWISE_WEIGHT * pairwise
+            for name in replies
+        }
+
+        best_name = max(final_scores, key=final_scores.get)
+        best_score = final_scores[best_name]
+
+        vals = list(final_scores.values())
+        mu = float(np.mean(vals)) if vals else 0.0
+        sigma = float(np.std(vals)) if vals else 0.0
+        truth_th = mu + TRUTH_Z * sigma
+
+        if best_score >= truth_th:
             self.state = State.CONVERGE
-        elif best_score < self.FLOOR_TH:
+        elif best_score < FLOOR_TH:
             self.state = State.DIVERGE
         else:
-            self.state = State.EVALUATE  # keep refining
+            self.state = State.EVALUATE
 
         return best_name, replies[best_name]
 
@@ -92,10 +136,24 @@ class CoordinatorFSM:
         emb = ollama_client.embed(text)          # fire‑and‑forget coroutine
         # we can't await inside summarise (engine will handle); placeholder
 
+    def summarise_round(self, guide: str, replies: Dict[str, str], critic: str, best: str | None = None) -> str:
+        parts = [f"Guide: {guide}"]
+        for name, rep in replies.items():
+            parts.append(f"{name}: {rep}")
+        if critic:
+            parts.append(f"Critic: {critic}")
+        if best is not None:
+            parts.append(f"Best: {best}")
+        text = "\n".join(parts)
+        self.summarise(text)
+        if best is not None and self.state is State.CONVERGE:
+            self.summarise(best)
+        return text
+
     # ....................................................
     def step_dialectic(self):
         self.dial_rounds += 1
-        if self.dial_rounds >= self.MAX_DIAL:
+        if self.dial_rounds >= MAX_DIAL:
             self.state = State.CONTRADICTION
 
 
@@ -105,6 +163,8 @@ async def detect_contradiction(text_a: str, text_b: str) -> bool:
     Cheap contradiction check via LLM call.
     Returns True if replies conflict.
     """
+    if contradict(text_a, text_b):
+        return True
     prompt = [
         {"role": "system", "content": (
             "Return YES if statement A contradicts statement B, else NO.")},

--- a/mrce/mrcore/engine.py
+++ b/mrce/mrcore/engine.py
@@ -14,6 +14,8 @@ from pathlib import Path
 from typing import Dict
 
 from rich import print
+import numpy as np
+from mrce.utils.logger import log_phi, logger
 
 from mrce.mrcore.loader import load_personae
 from mrce.mrcore.coordinator import CoordinatorFSM, State, detect_contradiction
@@ -25,46 +27,58 @@ class MRCEngine:
     def __init__(self):
         self.global_mem = PhaseCrystalMemory()
         self.coordinator = CoordinatorFSM(self.global_mem)
-        self.agents = load_personae(Path("configs/personae"))
+        loaded = load_personae(Path("configs/personae"))
+        self.critic = next((a for a in loaded if a.name.lower() == "critic"), None)
+        self.agents = [a for a in loaded if a is not self.critic and a.name.lower() != "coordinator"]
         self.turn = 0
+        self.prev_coord: str | None = None
 
     # ------------------------------------------------------------------
-    async def run_turn(self, user_msg: str) -> str:
+    async def run_turn(self, user_msg: str | None, debug: bool = False) -> str:
         """
-        One complete MRCE round:
-          guide → expert fan‑out → evaluate → converge/diverge logic
-        Returns text chosen by coordinator (best or distilled).
+        One MRCE round following the order:
+          user → coordinator → agents → critic → coordinator
+        Returns text chosen by coordinator.
         """
-        # FECR vector evolves from crystals each turn
         fecr_vec = update_from_crystals(self.global_mem.crystals)
-        context_state: Dict = {"fecr_vector": fecr_vec}
+        context_state: Dict = {"fecr_vector": fecr_vec, "user_input": user_msg or ""}
+        if debug:
+            logger.info(f"phi[0:4]={fecr_vec[:4]}")
 
-        # Coordinator guidance first
-        guide_txt = self.coordinator.guide(fecr_vec)
+        guide_txt = self.coordinator.guide(self.prev_coord, user_msg or "", fecr_vec)
         context_state["guide"] = guide_txt
 
-        # Broadcast to experts in parallel
-        tasks = [ag.step(user_msg, context_state) for ag in self.agents]
+        tasks = [ag.step(guide_txt, dict(context_state)) for ag in self.agents]
         replies = {ag.name: rep for ag, rep in zip(self.agents, await asyncio.gather(*tasks))}
 
-        # Evaluate & print round
-        best_name, best_text = await self.coordinator.evaluate(user_msg, replies)
-        print(f"[bold magenta]Coordinator state → {self.coordinator.state.name}")
-        for name, txt in replies.items():
-            print(f"[cyan][{name}][/]: {txt}\n")
+        critic_reply = ""
+        if self.critic:
+            critic_prompt = "\n".join(f"{n}: {r}" for n, r in replies.items())
+            critic_state = dict(context_state)
+            critic_state["agent_replies"] = replies
+            critic_reply = await self.critic.step(critic_prompt, critic_state)
+            context_state["critic"] = critic_reply
 
-        # State handling
-        if self.coordinator.state is State.CONVERGE:
-            self.coordinator.summarise(best_text)    # distilled truth crystal
-            self.turn += 1
-            return best_text
+        best_name, best_text = await self.coordinator.evaluate(user_msg or "", replies)
+        logger.info(f"Coordinator state → {self.coordinator.state.name}")
+        for name, txt in replies.items():
+            logger.info(f"[{name}] {txt}")
+        if critic_reply:
+            logger.info(f"[Critic] {critic_reply}")
+
+        summary = self.coordinator.summarise_round(guide_txt, replies, critic_reply, best_text)
+        self.prev_coord = summary
 
         if self.coordinator.state is State.DIVERGE:
-            # simple dialectic: pick two shortest replies, check contradiction
             names = sorted(replies, key=lambda n: len(replies[n]))[:2]
             if await detect_contradiction(replies[names[0]], replies[names[1]]):
                 self.coordinator.step_dialectic()
 
-        # otherwise EVALUATE continues
         self.turn += 1
+        metrics = [ag.memory.last_resonance for ag in self.agents]
+        coh = float(np.mean([ag.memory.last_coherence for ag in self.agents]))
+        spec = float(np.mean([ag.memory.last_dominant for ag in self.agents]))
+        res = float(np.mean(metrics))
+        log_phi(self.turn, fecr_vec, res, coh, spec)
+
         return best_text

--- a/mrce/settings.py
+++ b/mrce/settings.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+# Phase-Crystal parameters
+WINDOW = 128
+DECAY = 0.98
+THRESH = 0.85
+ALPHA = 0.6
+BETA = 0.4
+MAX_CRYSTALS = 64
+
+# Coordinator weights
+RESONANCE_WEIGHT = 0.6
+CRITIC_WEIGHT = 0.4
+INDIVIDUAL_WEIGHT = 0.4
+PAIRWISE_WEIGHT = 0.6
+TRUTH_Z = 0.75
+FLOOR_TH = 0.45
+MAX_DIAL = 3
+
+# Logging
+LOG_DIR = Path("logs")
+CSV_LOGGING = True

--- a/mrce/utils/logger.py
+++ b/mrce/utils/logger.py
@@ -6,13 +6,19 @@ Usage:
     log_turn(timestamp, persona, prompt, reply)
 """
 
-import csv, os, datetime
+import csv
+import datetime
 from pathlib import Path
+import logging
+from rich.logging import RichHandler
 
-LOG_DIR = Path("logs")
+from mrce.settings import LOG_DIR, CSV_LOGGING
+
 LOG_DIR.mkdir(exist_ok=True)
 
-CSV_LOGGING = True   # ← toggle logging on/off globally
+logger = logging.getLogger("mrce")
+logger.setLevel(logging.INFO)
+logger.addHandler(RichHandler())
 
 # Determine next incremental file name
 existing = sorted(LOG_DIR.glob("MRCE_chat_*.csv"))
@@ -35,3 +41,21 @@ def log_turn(persona: str, prompt: str, response: str):
     ts = datetime.datetime.now().isoformat(timespec="seconds")
     with _log_path.open("a", newline="", encoding="utf-8") as f:
         csv.writer(f).writerow([ts, persona, prompt, response])
+
+
+def log_phi(turn: int, phi: list[float], resonance: float, coherence: float, spectral: float):
+    if not CSV_LOGGING:
+        return
+    path = LOG_DIR / "phi.csv"
+    header = not path.exists()
+    with path.open("a", newline="", encoding="utf-8") as f:
+        wr = csv.writer(f)
+        if header:
+            wr.writerow([
+                "turn",
+                "resonance",
+                "coherence",
+                "spectral",
+                *[f"phi_{i}" for i in range(len(phi))],
+            ])
+        wr.writerow([turn, resonance, coherence, spectral, *phi])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+numpy
+scipy
+httpx
+pyyaml
+rich
+pytest

--- a/scripts/smoke_engine.py
+++ b/scripts/smoke_engine.py
@@ -1,15 +1,24 @@
 import asyncio
+import argparse
 from mrce.mrcore.engine import MRCEngine
+from mrce.mrcore.coordinator import State
 
 async def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--debug", action="store_true", help="print FECR details")
+    args = parser.parse_args()
+
     engine = MRCEngine()
 
+    user_msg = input("\nUSER > ")
     while True:
-        user_msg = input("\nUSER > ")
         if user_msg.lower() in {"exit", "quit"}:
             break
-        reply = await engine.run_turn(user_msg)
+        reply = await engine.run_turn(user_msg, debug=args.debug)
         print(f"\n[MRCE] {reply}")
+        if engine.coordinator.state in {State.CONVERGE, State.CONTRADICTION}:
+            break
+        user_msg = input("\nUSER > ")
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -11,3 +11,12 @@ def test_promotion_cap():
 
     # We expect at most 3 crystals in random noise
     assert len(mem.crystals) <= 3
+
+
+def test_resonance_monotonic():
+    mem = PhaseCrystalMemory()
+    rng = np.random.default_rng(0)
+    vec = rng.normal(size=768).astype("float32")
+    for _ in range(10):
+        mem.add(vec + 0.01 * rng.normal(size=768))
+    assert all(np.diff(mem.scores) >= -1e-3)


### PR DESCRIPTION
## Summary
- revise `MRCEngine` loop so the coordinator guides each round
- recency-weighted memory coherence and Welch spectral frequency
- additive modulator gain to keep embedding norms stable
- improved logging and configuration constants
- document setup and new workflow in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68487356fccc8326bad60e3ef27ed953